### PR TITLE
同步作者代码

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ var b = browserify({
   packageCache: {},
   entries: ['./app/js/app.js'],
   debug: !isProduction,
-  transform: ['reactify']
+  transform: ['babelify']
 });
 
 if (!isProduction) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "amazeui": "^2.4.0",
     "amazeui-react": "latest",
+    "babelify": "^6.1.2",
     "browser-sync": "^2.6.4",
     "browserify": "^10.2.1",
     "browserify-shim": "^3.8.7",
@@ -38,7 +39,6 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.4",
-    "reactify": "^1.1.0",
     "run-sequence": "^1.0.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
babelify取代reactify，准备弃用jstransform

- see https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html